### PR TITLE
Add Consul integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /config
 /*.ign
 /tls
+/ignition

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,36 @@
 .PHONY: all common bootstrap servers clients
+OUTPUT ?= ignition
 
 include secrets
 
-all:
+
+${OUTPUT}:
+	mkdir -p ${OUTPUT}
+
+all: ${OUTPUT}
 	make bootstrap
 	make servers
 	make clients
 
-common:
+common: ${OUTPUT}
 	rm -rf ./config
 	cp -a template config
 	cp -a tls config/tls
 	find config/ -type f -print0 | xargs -0 sed -i 's/%%DATACENTER%%/${DATACENTER}/g'
 
 bootstrap: common
-	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - bootstrap.bu | butane --files-dir config --strict --output server-1.ign
+	find config/ -type f -print0 | xargs -0 sed -i 's/%%CONSUL_ENCRYPT_KEY%%/${CONSUL_ENCRYPT_KEY}/g'
+	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - bootstrap.bu | sed 's|%%NODE_IP_SUFFIX%%|100|' | sed 's|%%NODE_DNS%%|${NODE_DNS}|' | sed 's|%%NODE_GATEWAY%%|${NODE_GATEWAY}|' | sed 's|%%NODE_IP_PREFIX%%|${NODE_IP_PREFIX}|' | butane --files-dir config --strict --output ${OUTPUT}/server-0.ign
 
 servers: common
 	find config/ -type f -print0 | xargs -0 sed -i 's/%%BOOTSTRAP_IP%%/${BOOTSTRAP_IP}/g'
-	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - server.bu | sed 's|%%NUMBER%%|2|' | butane --files-dir config --strict --output server-2.ign
-	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - server.bu | sed 's|%%NUMBER%%|3|' | butane --files-dir config --strict --output server-3.ign
+	find config/ -type f -print0 | xargs -0 sed -i 's/%%CONSUL_ENCRYPT_KEY%%/${CONSUL_ENCRYPT_KEY}/g'
+	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - server.bu | sed 's|%%NODE_IP_SUFFIX%%|101|' | sed 's|%%NUMBER%%|1|' | sed 's|%%NODE_DNS%%|${NODE_DNS}|' | sed 's|%%NODE_GATEWAY%%|${NODE_GATEWAY}|' | sed 's|%%NODE_IP_PREFIX%%|${NODE_IP_PREFIX}|' | butane --files-dir config --strict --output ${OUTPUT}/server-1.ign
+	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - server.bu | sed 's|%%NODE_IP_SUFFIX%%|102|' | sed 's|%%NUMBER%%|2|' | sed 's|%%NODE_DNS%%|${NODE_DNS}|' | sed 's|%%NODE_GATEWAY%%|${NODE_GATEWAY}|' | sed 's|%%NODE_IP_PREFIX%%|${NODE_IP_PREFIX}|' | butane --files-dir config --strict --output ${OUTPUT}/server-2.ign
 
 clients: common
 	find config/ -type f -print0 | xargs -0 sed -i 's/%%BOOTSTRAP_IP%%/${BOOTSTRAP_IP}/g'
-	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - client.bu | sed 's|%%NUMBER%%|1|' |  butane --files-dir config --strict --output client-1.ign
-	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - client.bu | sed 's|%%NUMBER%%|2|' |  butane --files-dir config --strict --output client-2.ign
-	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - client.bu | sed 's|%%NUMBER%%|3|' |  butane --files-dir config --strict --output client-3.ign
+	find config/ -type f -print0 | xargs -0 sed -i 's/%%CONSUL_ENCRYPT_KEY%%/${CONSUL_ENCRYPT_KEY}/g'
+	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - client.bu | sed 's|%%NODE_IP_SUFFIX%%|110|' | sed 's|%%NUMBER%%|0|' | sed 's|%%NODE_DNS%%|${NODE_DNS}|' | sed 's|%%NODE_GATEWAY%%|${NODE_GATEWAY}|' | sed 's|%%NODE_IP_PREFIX%%|${NODE_IP_PREFIX}|' | butane --files-dir config --strict --output ${OUTPUT}/client-0.ign
+	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - client.bu | sed 's|%%NODE_IP_SUFFIX%%|111|' | sed 's|%%NUMBER%%|1|' | sed 's|%%NODE_DNS%%|${NODE_DNS}|' | sed 's|%%NODE_GATEWAY%%|${NODE_GATEWAY}|' | sed 's|%%NODE_IP_PREFIX%%|${NODE_IP_PREFIX}|' | butane --files-dir config --strict --output ${OUTPUT}/client-1.ign
+	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' common.bu | cat - client.bu | sed 's|%%NODE_IP_SUFFIX%%|112|' | sed 's|%%NUMBER%%|2|' | sed 's|%%NODE_DNS%%|${NODE_DNS}|' | sed 's|%%NODE_GATEWAY%%|${NODE_GATEWAY}|' | sed 's|%%NODE_IP_PREFIX%%|${NODE_IP_PREFIX}|' | butane --files-dir config --strict --output ${OUTPUT}/client-2.ign

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Butane configs to deploy Nomad on Fedora CoreOS
+# Butane configs to deploy Consul and Nomad on Fedora CoreOS
 
-The Butane configurations from this project will deploy Nomad as described in
+The Butane configurations from this project will deploy Consul and Nomad as described in
 the [Nomad Reference Architecture][nomad-ref-arch], using the [podman
 driver][podman-driver].
 
@@ -8,13 +8,13 @@ This also includes support for the [Enable TLS Encryption for Nomad][nomad-tls]
 guide to enable mutual TLS encryption and authentication.
 
 This will enable you to setup:
-  * A Nomad bootstrap server,
-  * Two other servers to enable the election to proceed and have a leader and
+  * A bootstrap server running Consul and Nomad
+  * Two other servers that run Consul and Nomad in server mode to enable the election to proceed and have a leader and
     two followers,
-  * Three clients (but you can spawn as many as you need for your workload).
+  * Three Nomad and Consul clients (but you can spawn as many as you need for your workload).
 
-**Note that this setup does not currently include Consul and Vault support which
-are recommended in production setups.**
+**Note that this setup does not currently include Vault support which
+is recommended in production setups.**
 
 ## How to use
 
@@ -58,7 +58,7 @@ clients:
 $ make bootstrap
 ```
 
-This will generate the `server-1.ign` Ignition config that you can use to
+This will generate the `ignition/server-0.ign` Ignition config that you can use to
 deploy your Fedora CoreOS Nomad bootstrap server. See the [Fedora CoreOS
 docs][deploy] for instructions on how to use this Ignition config to deploy a
 Fedora CoreOS instance on your prefered platform.
@@ -77,7 +77,7 @@ And then generate the configurations for the additionnal servers:
 $ make servers
 ```
 
-This will generate the `server-{2,3}` Ignition configs that you can use to
+This will generate the `ignition/server-{1,2}` Ignition configs that you can use to
 deploy the two additional server instances.
 
 Then do the same for the clients:
@@ -86,7 +86,7 @@ Then do the same for the clients:
 $ make clients
 ```
 
-This will generate the `client-{1,2,3}` Ignition configs that you can use to
+This will generate the `ignition/client-{0,1,2}` Ignition configs that you can use to
 deploy the three client instances.
 
 ### Testing that the deployment succeeded
@@ -98,21 +98,27 @@ $ export NOMAD_ADDR=https://localhost:4646
 $ export NOMAD_CACERT=tls/nomad-ca.pem
 $ export NOMAD_CLIENT_CERT=tls/cli.pem
 $ export NOMAD_CLIENT_KEY=tls/cli-key.pem
+$ export CONSUL_HTTP_ADDR=https://localhost:8501
+$ export CONSUL_CACERT=tls/nomad-ca.pem
+$ export CONSUL_CLIENT_CERT=tls/cli.pem
+$ export CONSUL_CLIENT_KEY=tls/cli-key.pem
+
 ```
 
 Setup an SSH tunnel to a server node:
 
 ```
-$ ssh core@SERVER_IP -L 4646:localhost:4646 -N
+$ ssh core@SERVER_IP -L 8501:localhost:8501  -L 4646:localhost:4646 -N
 ```
 
-You can list the servers that are part of your cluster with:
+You can list the nomad and consul servers and client that are part of your cluster with:
 
 ```
+$ consul members
 $ nomad server members
 ```
 
-And list the client nodes with:
+And list the nomad client nodes with:
 
 ```
 $ nomad node status

--- a/bootstrap.bu
+++ b/bootstrap.bu
@@ -1,7 +1,7 @@
     - path: /etc/hostname
       mode: 0644
       contents:
-        inline: nomad-server-1
+        inline: nomad-server-0
     - path: /etc/nomad.d/bootstrap.hcl
       contents:
         local: bootstrap.hcl
@@ -13,4 +13,8 @@
     - path: /etc/nomad.certs/server-key.pem
       contents:
         local: tls/server-key.pem
+      mode: 0600
+    - path: /etc/consul.d/bootstrap.hcl
+      contents:
+        local: consul-bootstrap.hcl
       mode: 0600

--- a/client.bu
+++ b/client.bu
@@ -14,3 +14,7 @@
       contents:
         local: tls/client-key.pem
       mode: 0600
+    - path: /etc/consul.d/client.hcl
+      contents:
+        local: consul-client.hcl
+      mode: 0600

--- a/common.bu
+++ b/common.bu
@@ -44,9 +44,9 @@ systemd:
         [Unit]
         Description=Nomad
         Documentation=https://www.nomadproject.io/docs/
-        After=network-online.target nomad-binaries.service
+        After=network-online.target nomad-binaries.service consul-agent.service
         Wants=network-online.target
-        Requires=nomad-binaries.service
+        Requires=nomad-binaries.service consul-agent.service
 
         # When using Nomad with Consul it is not necessary to start Consul first. These
         # lines start Consul before Nomad as an optimization to avoid Nomad logging
@@ -69,6 +69,58 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 
+    - name: consul-binaries.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Pull consul binaries
+        After=network-online.target
+        Wants=network-online.target
+        ConditionPathExists=!/usr/local/bin/consul
+        ConditionPathExists=!/usr/local/lib/consul/plugins/consul-driver-podman
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=podman create --name consul-binaries quay.io/ramblurr/consul
+        ExecStart=podman cp consul-binaries:/consul /usr/local/bin/consul
+        ExecStart=podman rm -f consul-binaries
+        ExecStart=podman rmi quay.io/ramblurr/consul
+        ExecStart=restorecon -RFv /usr/local/bin/consul
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: consul-agent.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=consul
+        Documentation=https://www.consulproject.io/docs/
+        After=network-online.target consul-binaries.service
+        Wants=network-online.target
+        Requires=consul-binaries.service
+
+        # When using consul with Consul it is not necessary to start Consul first. These
+        # lines start Consul before consul as an optimization to avoid consul logging
+        # that Consul is unavailable at startup.
+        #Wants=consul.service
+        #After=consul.service
+
+        [Service]
+        ExecReload=/bin/kill -HUP $MAINPID
+        ExecStart=/usr/local/bin/consul agent -config-dir /etc/consul.d
+        KillMode=process
+        KillSignal=SIGINT
+        LimitNOFILE=65536
+        LimitNPROC=infinity
+        Restart=on-failure
+        RestartSec=2
+        TasksMax=infinity
+        OOMScoreAdjust=-1000
+
+        [Install]
+        WantedBy=multi-user.target
 storage:
   directories:
     - path: /etc/nomad.d
@@ -79,6 +131,10 @@ storage:
       mode: 0711
     - path: /usr/local/lib/nomad/plugins
       mode: 0755
+    - path: /etc/consul.d
+      mode: 0700
+    - path: /var/lib/consul
+      mode: 0711
   files:
     - path: /etc/nomad.d/common.hcl
       contents:
@@ -88,3 +144,22 @@ storage:
       contents:
         local: tls/nomad-ca.pem
       mode: 0600
+    - path: /etc/consul.d/common.hcl
+      contents:
+        local: consul-common.hcl
+      mode: 0600
+    - path: /etc/NetworkManager/system-connections/ens18.nmconnection
+      mode: 0600
+      contents:
+        inline: |
+          [connection]
+          id=ens18
+          type=ethernet
+          interface-name=ens18
+          [ipv4]
+          address1=%%NODE_IP_PREFIX%%%%NODE_IP_SUFFIX%%/22
+          gateway=%%NODE_GATEWAY%%
+          dns=%%NODE_DNS%%
+          dns-search=
+          may-fail=false
+          method=manual

--- a/secrets.example
+++ b/secrets.example
@@ -1,3 +1,7 @@
 SSH_PUBKEY=ssh-rsa AAAA...
 DATACENTER=fcos-nomad-demo
 BOOTSTRAP_IP=W.X.Y.Z
+CONSUL_ENCRYPT_KEY=output of `consul keygen`
+NODE_IP_PREFIX=W.X.Y.
+NODE_GATEWAY=W.X.Y.Z
+NODE_DNS=W.X.Y.Z;W.Z.Y.Z;

--- a/server.bu
+++ b/server.bu
@@ -14,3 +14,6 @@
       contents:
         local: tls/server-key.pem
       mode: 0600
+    - path: /etc/consul.d/server.hcl
+      contents:
+        local: consul-server.hcl

--- a/template/bootstrap.hcl
+++ b/template/bootstrap.hcl
@@ -14,3 +14,11 @@ tls {
   verify_server_hostname = true
   verify_https_client    = true
 }
+
+consul {
+  address = "127.0.0.1:8501"
+  client_service_name = "nomad-server"
+  auto_advertise = true
+  server_auto_join = true
+  client_auto_join = true
+}

--- a/template/client.hcl
+++ b/template/client.hcl
@@ -14,3 +14,14 @@ tls {
   verify_server_hostname = true
   verify_https_client    = true
 }
+
+consul {
+  address = "127.0.0.1:8501"
+  client_service_name = "nomad-client"
+  auto_advertise = true
+  server_auto_join = true
+  client_auto_join = true
+  ca_file   = "/etc/nomad.certs/nomad-ca.pem"
+  cert_file = "/etc/nomad.certs/client.pem"
+  key_file  = "/etc/nomad.certs/client-key.pem"
+}

--- a/template/consul-bootstrap.hcl
+++ b/template/consul-bootstrap.hcl
@@ -1,0 +1,15 @@
+server = true
+ui_config{
+  enabled = true
+}
+client_addr = "0.0.0.0"
+advertise_addr = ""
+advertise_addr_wan = ""
+bind_addr = "{{GetInterfaceIP \"ens18\"}}"
+bootstrap_expect = 3
+ca_file   = "/etc/nomad.certs/nomad-ca.pem"
+cert_file = "/etc/nomad.certs/server.pem"
+key_file  = "/etc/nomad.certs/server-key.pem"
+telemetry {
+  disable_compat_1.9 = true
+}

--- a/template/consul-client.hcl
+++ b/template/consul-client.hcl
@@ -1,0 +1,15 @@
+server = false
+ui_config{
+  enabled = true
+}
+client_addr = "0.0.0.0"
+advertise_addr = ""
+advertise_addr_wan = ""
+bind_addr = "{{GetInterfaceIP \"ens18\"}}"
+ca_file   = "/etc/nomad.certs/nomad-ca.pem"
+cert_file = "/etc/nomad.certs/client.pem"
+key_file  = "/etc/nomad.certs/client-key.pem"
+retry_join = [ "%%BOOTSTRAP_IP%%" ]
+telemetry {
+  disable_compat_1.9 = true
+}

--- a/template/consul-common.hcl
+++ b/template/consul-common.hcl
@@ -1,0 +1,9 @@
+datacenter = "%%DATACENTER%%"
+data_dir = "/var/lib/consul"
+enable_syslog = true
+log_level = "info"
+encrypt = "%%CONSUL_ENCRYPT_KEY%%"
+verify_incoming = true
+verify_outgoing = true
+verify_server_hostname = false
+ports {  http = -1  https = 8501}

--- a/template/consul-server.hcl
+++ b/template/consul-server.hcl
@@ -1,0 +1,16 @@
+server = true
+ui_config{
+  enabled = true
+}
+client_addr = "0.0.0.0"
+advertise_addr = ""
+advertise_addr_wan = ""
+bind_addr = "{{GetInterfaceIP \"ens18\"}}"
+bootstrap_expect = 3
+ca_file   = "/etc/nomad.certs/nomad-ca.pem"
+cert_file = "/etc/nomad.certs/server.pem"
+key_file  = "/etc/nomad.certs/server-key.pem"
+retry_join = [ "%%BOOTSTRAP_IP%%" ]
+telemetry {
+  disable_compat_1.9 = true
+}

--- a/template/server.hcl
+++ b/template/server.hcl
@@ -18,3 +18,14 @@ tls {
   verify_server_hostname = true
   verify_https_client    = true
 }
+
+consul {
+  address = "127.0.0.1:8501"
+  client_service_name = "nomad-server"
+  auto_advertise = true
+  server_auto_join = true
+  client_auto_join = true
+  ca_file   = "/etc/nomad.certs/nomad-ca.pem"
+  cert_file = "/etc/nomad.certs/client.pem"
+  key_file  = "/etc/nomad.certs/client-key.pem"
+}


### PR DESCRIPTION
Here's an initial pass at #3. 

This PR installs Consul on the same nodes as the Nomad servers/clients. It uses this [consul](https://github.com/ramblurr/quay-containerfiles/tree/consul) image for installing the binaries. The HTTP API is disabled, only HTTPS is enabled with client TLS verification.

I chose to statically assign IPs to the nodes, hence some of the new config. I suppose this strictly speaking isn't necessary and could be removed.

Things are starting to get messy with the string substitution and  config file explosion, so moving to ansible or terraform to generate the configs probably isn't a bad idea.